### PR TITLE
Fully update to 1.21

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,14 +3,14 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.21-pre1
-	yarn_mappings=1.21-pre1+build.4
+	minecraft_version=1.21
+	yarn_mappings=1.21+build.2
 	loader_version=0.15.11
 	# check available versions on maven (https://masa.dy.fi/maven/carpet/fabric-carpet/) for the given minecraft version you are using
-	carpet_core_version=1.4.145+v240529
+	carpet_core_version=1.4.147+v240613
 
 # Mod Properties
-	mod_version = 1.4.145
+	mod_version = 1.4.147
 	maven_group = carpet-extra
 	archives_base_name = carpet-extra
 
@@ -21,7 +21,7 @@ org.gradle.jvmargs=-Xmx1G
 	# The Curseforge versions "names" or ids for the main branch (comma separated: 1.16.4,1.16.5)
 	# This is needed because CF uses too vague names for prereleases and release candidates
 	# Can also be the version ID directly coming from https://minecraft.curseforge.com/api/game/versions?token=[API_TOKEN]
-	release-curse-versions = Minecraft 1.21:1.21-Snapshot
+	release-curse-versions = Minecraft 1.21:1.21
 	# Whether or not to build another branch on release
 	release-extra-branch = false
 	# The name of the second branch to release

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,8 +28,8 @@
 
   "depends": {
     "fabricloader": ">=0.15.11",
-    "carpet": ">=1.4.145",
-    "minecraft": ["1.21-beta.1"],
+    "carpet": ">=1.4.147",
+    "minecraft": ["1.21"],
     "java": ">=21"
   },
   "custom": {


### PR DESCRIPTION
yo dawg, i updated your update so you can update your update while updating

in all seriousness though, i synced the carpet version in the dependencies, the Minecraft version and relevant references to carpet core, and yarn mappings.

With this you should be able to mark your PR as non-draft, though you may need to rename the branch i guess? it's not 1.21-pre1 but just 1.21 now after all